### PR TITLE
Fix command in use/step3

### DIFF
--- a/use/step3/text.md
+++ b/use/step3/text.md
@@ -22,7 +22,7 @@ helm install -h
 <br>
 
 ```plain
-helm -n team-yellow install devserver nginx-stable/nginx-ingress
+helm -n team-yellow install devserver nginx-stable/nginx-ingress --set controller.debug.enable=false
 ```{{exec}}
 
 </details>


### PR DESCRIPTION
I was unable to complete the tutorial. I tried it several times, went to https://docs.nginx.com/nginx-ingress-controller/install/helm/open-source/ to check for any pointers upstream and pulled the chart with `helm pull oci://ghcr.io/nginx/charts/nginx-ingress --untar` to work on a local copy.

Finally I asked duck.ai, described my issue and, after some edits on the suggested solution, I arrived at this solution to complete the tutorial.

You may want to include an explanation, like it is done on some other tutorials.

---

From the killercoda environment:
 
 ```
 controlplane:~$ helm -n team-yellow install devserver nginx-stable/nginx-ingress
Error: INSTALLATION FAILED: template: nginx-ingress/templates/controller-deployment.yaml:174:4: executing "nginx-ingress/templates/controller-deployment.yaml" at <include "nginx-ingress.args" .>: error calling include: template: nginx-ingress/templates/_helpers.tpl:254:43: executing "nginx-ingress.args" at <.Values.controller.debug.enable>: nil pointer evaluating interface {}.enable
 ```

 ```
controlplane:~$ helm -n team-yellow install devserver nginx-stable/nginx-ingress \
                      --set controller.debug.enable=false
NAME: devserver
LAST DEPLOYED: Thu Feb 19 12:47:33 2026
NAMESPACE: team-yellow
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
NGINX Ingress Controller 5.3.4 has been installed.

For release notes, see: https://docs.nginx.com/nginx-ingress-controller/changelog/

For Helm installation instructions, see: https://docs.nginx.com/nginx-ingress-controller/install/helm/
```