### PR TITLE
[PRODUCTION_SCENARIO] Upgrading Helm version, versions lower then 4.0…

### DIFF
--- a/production/assets/init.sh
+++ b/production/assets/init.sh
@@ -12,11 +12,11 @@ bash /ks/k8s.sh
 
 
 # scenario specific
-wget https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz
-tar xzf helm-v3.8.2-linux-amd64.tar.gz
+wget https://get.helm.sh/helm-v4.1.1-linux-amd64.tar.gz
+tar xzf helm-v4.1.1-linux-amd64.tar.gz
 mv linux-amd64/helm /usr/bin/
 chmod a+x /usr/bin/helm
-rm -rf linux-amd64 helm-v3.8.2-linux-amd64.tar.gz
+rm -rf linux-amd64 helm-v4.1.1-linux-amd64.tar.gz
 
 
 helm repo add nginx-stable https://helm.nginx.com/stable

--- a/production/step2/text.md
+++ b/production/step2/text.md
@@ -1,5 +1,5 @@
 ### Helm upgrade flags
 
 Beside the flags for the `install` command, the `upgrade` command has the `--cleanup-on-fail` flag which will allow the deletion of the new resources introduced in the upgrade.
-It can be used together with the `--atomic` for reverting the release to the revision before the upgrade, because using only `--atomic` means that the resources present before the upgrade will stay the same but the newly introduced resources (if they exists) will be left dangling in the cluster.
+It can be used together with the `--rollback-on-failure` for reverting the release to the revision before the upgrade, because using only `--rollback-on-failure` means that the resources present before the upgrade will stay the same but the newly introduced resources (if they exists) will be left dangling in the cluster.
 


### PR DESCRIPTION
The project uses a quite obsolete Helm version (3.8), which doesn't include some breaking changes e.g. changed name of '--atomic' flag to '--rollback-on-failure' (PR #13629). I updated a helm version and instruction in "step2" according to current name convention.  